### PR TITLE
Better async support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2436,6 +2436,32 @@
         }
       }
     },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "requires": {
+        "bluebird": "3.5.1",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
+      }
+    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -2789,6 +2815,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-counter": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hubot-rules": "0.1.2",
     "hubot-scripts": "2.17.2",
     "hubot-slack": "4.4.0",
-    "request-promise": "^4.2.2"
+    "request-promise": "4.2.2"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "hubot-redis-brain": "0.0.4",
     "hubot-rules": "0.1.2",
     "hubot-scripts": "2.17.2",
-    "hubot-slack": "4.4.0"
+    "hubot-slack": "4.4.0",
+    "request-promise": "^4.2.2"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/scripts/pugme.js
+++ b/scripts/pugme.js
@@ -8,21 +8,38 @@
 //   None
 //
 // Commands:
-//   randbot pug me - Receive a pug
-//   randbot pug bomb N - get N pugs (max 10)
+//   hubot pug me - Receive a pug
+//   hubot pug bomb N - get N pugs (max 10)
 
-module.exports = function (robot) {
-  robot.respond(/pug me/i, (msg) => {
-    msg.http('http://pugme.herokuapp.com/random').get()((err, res, body) => {
-      msg.send(JSON.parse(body).pug);
-    });
+const request = require('request-promise');
+
+module.exports = (robot) => {
+  robot.respond(/pug me/i, async (msg) => {
+    try {
+      const response = await request({
+        url: 'http://pugme.herokuapp.com/random',
+        json: true
+      });
+      msg.send(response.pug);
+    }
+    catch (err) {
+      msg.send('You dun goofed now!');
+    }
   });
-  robot.respond(/pug bomb( (\d+))?/i, (msg) => {
-    console.log(msg.match[2]);
+
+  robot.respond(/pug bomb( (\d+))?/i, async (msg) => {
     const count = parseInt(msg.match[2], 10) > 10 ? 10 : parseInt(msg.match[2], 10) || 5;
 
-    return msg.http(`http://pugme.herokuapp.com/bomb?count=${count}`).get()((err, res, body) => {
-      JSON.parse(body).pugs.forEach(p => msg.send(p));
-    });
+    try {
+      const response = await request({
+        url: `http://pugme.herokuapp.com/bomb?count=${count}`
+      });
+      response.pugs.forEach(p => msg.send(p));
+    }
+    catch (err) {
+      [...Array(count).keys()]
+      .map(() => 'You dun goofed now!')
+      .forEach(m => msg.send(m));
+    }
   });
 };


### PR DESCRIPTION
Closes #19 

- Pulled in `request-promise` which is basically `request` (defacto node HTTP client) coupled with `bluebird`'s `promisifyAll`
- Start using `async/await` in our code so it looks all synchronous because we're using Node 8
- If something goes wrong with the pug bomb, robotk will reply with the requested number of `you dun goofed` messages.