### PR TITLE
Added some logging to catch an error

### DIFF
--- a/middleware/discuss.js
+++ b/middleware/discuss.js
@@ -12,6 +12,10 @@ const { automod } = require('../support/strings');
 // because we use the wrap function to forward errors to the client.
 module.exports = async function discuss(req, res) {
   const { userName } = parseUsername(req.body.text);
+  if (!userName) {
+    res.send('You didn\'t give me a user, try the command again with an `@user`.');
+    return;
+  }
   const channelName = `discuss_${userName}`;
   const { SLACK_API_TOKEN } = process.env;
 

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -2,10 +2,12 @@ const isAdminCheck = require('./isAdmin');
 const verifyIncomingWebhook = require('./verifyWebhook');
 const discuss = require('./discuss');
 const kickEveryone = require('./kickEveryone');
+const logWhenError = require('./logWhenError');
 
 module.exports = {
   isAdminCheck,
   verifyIncomingWebhook,
   discuss,
-  kickEveryone
+  kickEveryone,
+  logWhenError
 };

--- a/middleware/logWhenError.js
+++ b/middleware/logWhenError.js
@@ -1,0 +1,12 @@
+// This function literally has to look like this
+// even though we're not using res and next for all
+// the error handling through express 3.12 to resolve
+// properly. Thanks hubot 👌
+
+module.exports = (err, req, res, next) => { // eslint-disable-line no-unused-vars
+  // intercept the error that's happening and log it
+  if (process.env.DEBUG === 'true') {
+    console.log(`There was an error while ${req.method} ${req.originalUrl}`);
+    console.log(JSON.stringify(req.body, null, 2));
+  }
+};

--- a/scripts/automod.js
+++ b/scripts/automod.js
@@ -17,10 +17,12 @@ const {
   verifyIncomingWebhook,
   isAdminCheck,
   discuss,
-  kickEveryone
+  kickEveryone,
+  logWhenError
 } = require('../middleware');
 
 module.exports = (robot) => {
+  robot.router.all('*', logWhenError);
   robot.router.post('/automod/discuss', verifyIncomingWebhook, wrap(isAdminCheck), wrap(discuss));
   robot.router.post('/automod/kick_everyone', verifyIncomingWebhook, wrap(isAdminCheck), wrap(kickEveryone));
 };

--- a/support/slack.js
+++ b/support/slack.js
@@ -113,6 +113,10 @@ async function createOrUnarchiveGroup(token, channelName) {
     await unarchiveGroup(token, channel.id);
   }
 
+  if (process.env.DEBUG === 'true') {
+    console.log(channel);
+  }
+
   return channel;
 }
 

--- a/support/wrapAsync.js
+++ b/support/wrapAsync.js
@@ -1,1 +1,7 @@
-module.exports = fn => (...args) => fn(...args).catch(args[2]);
+const { logWhenError } = require('../middleware');
+
+module.exports = fn => (...args) => fn(...args).catch((e) => {
+  // args looks like [req, res, next]
+  logWhenError(e, ...args);
+  return args[2](e);
+});


### PR DESCRIPTION
* return an error when the user doesn't pass in another user
* added some logging to `createOrUnarchiveGroup` which is where things broke down
* added a middleware called `logWhenError` which logs only when an error happens
* wired up the error middleware

Alright, is it rant time yet?!

`<rant>`
Hubot, in all its wisdom uses Express 3 instead of Express 4 which has been out _forever_! So error handling is all fucked up so what we had to do was hook into the promise error handler. The `logWhenError` function has to take exactly 4 parameters otherwise things break because Express 3 determines what kind of middleware it is by doing some bullshitass reflection and if it doesn't take 4 parameters, then things literally don't work. 👏 Wow, just wow. 
`</rant>`

Anyway, please review. 