### PR TITLE
fix discuss command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 .DS_Store*
 .hubot_history
-*.env
+*.env*
 *.swp

--- a/middleware/verifyWebhook.js
+++ b/middleware/verifyWebhook.js
@@ -5,6 +5,6 @@ module.exports = function verifyIncomingWebhook(req, res, next) {
     next();
   }
   else {
-    res.sendStatus(403);
+    res.send(403);
   }
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "request-promise": "4.2.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": "8.11.x",
+    "npm": "5.6.x"
   },
   "devDependencies": {
     "chai": "4.1.2",

--- a/support/slack.js
+++ b/support/slack.js
@@ -1,4 +1,5 @@
 const request = require('request-promise');
+const _ = require('lodash');
 
 async function createGroup(token, name) {
   return request({
@@ -104,13 +105,35 @@ async function postMessage(token, channel, text, options) {
   });
 }
 
-async function createOrUnarchiveGroup(token, channelName) {
+async function createOrUnarchiveGroup(token, channelName, fudgeFactor) {
+  const isNameTakenError = e => !e.ok && e.error === 'name_taken';
+
   const createResponse = await createGroup(token, channelName);
   const channelList = await listGroups(token);
   const channel = channelList.groups.filter(g => g.name === channelName)[0];
 
-  if (!createResponse.ok && createResponse.error === 'name_taken') {
-    await unarchiveGroup(token, channel.id);
+  if (isNameTakenError(createResponse)) {
+    // the channel apparently exists but slack has decided to not
+    // return it in the list of groups because slack is great
+    if (!channel && _.isNil(fudgeFactor)) {
+      throw new Error('SLACK_IS_DUMB');
+    }
+    else if (!channel && !_.isNil(fudgeFactor)) {
+      const fudgedChannelName = `${channelName}${fudgeFactor}`;
+
+      const response = await createGroup(token, fudgedChannelName);
+      const groupList = await listGroups(token);
+      const fudgedChannel = groupList.groups.filter(g => g.name === fudgedChannelName)[0];
+
+      if (isNameTakenError(response)) {
+        await unarchiveGroup(token, fudgedChannel.id);
+      }
+
+      return fudgedChannel;
+    }
+
+    const response = await unarchiveGroup(token, channel.id);
+    console.log(response);
   }
 
   if (process.env.DEBUG === 'true') {
@@ -140,6 +163,11 @@ function parseUsername(userString) {
   return {};
 }
 
+function parseCommand(command) {
+  const [userString, fudgeFactor] = command.split(' ');
+  return { fudgeFactor, ...parseUsername(userString) };
+}
+
 module.exports = {
   createGroup,
   archiveGroup,
@@ -154,5 +182,6 @@ module.exports = {
   postMessage,
   createOrUnarchiveGroup,
   isUserAdmin,
-  parseUsername
+  parseUsername,
+  parseCommand
 };

--- a/support/strings.json
+++ b/support/strings.json
@@ -1,6 +1,7 @@
 {
   "automod": {
     "discussionChannelPurpose": "This channel’s purpose is to discuss and vote on a #{MEMBER_NAME}’s membership to #core. Please take some time to vote and voice any notes or concerns about #{MEMBER_NAME}. We will give everyone at least 24 hours to respond. A non response will result in your opinion not being accounted for. After the discussion and poll this channel will self destruct.",
-    "pollMessage": "/poll \"Should we invite #{MEMBER_NAME} to #core?\" \"Yes\" \"No\""
+    "pollMessage": "/poll \"Should we invite #{MEMBER_NAME} to #core?\" \"Yes\" \"No\"",
+    "slackIsDumb": "This channel apparently exists but Slack has decided that it's not going to tell me about it. Run the command again with a number at the end, like so `/discuss @user <some_number>`, and I'll create a new channel for you."
   }
 }


### PR DESCRIPTION
## The issue
The current way that automod tries to create discussion groups is try to create a group, if it exists already, unarchive it and then add all the members to it. This process depends on Slack returning the full list of private channels to us every time we ask. _Apparently_ there is a case where a channel is created but it won't be returned in the full list of private channels so we get into the issue of not being able to create it and not being able to unarchive it. 

## The fix
To fix this, I return a message to the user telling them to run the command again with a number at the end so that I can postfix it to the channel name and create an entirely new private channel. It follows the same create, find, unarchive logic that automod does already but for a channel with a slightly different name. 

## Other fixes
* apparently Express 3 uses `send` instead of `sendStatus`
* ignore all manners of `.env` files
* specifically set the `node` and `npm` versions for heroku (we need node 8.6.x or higher for the [object spread operator](https://github.com/hash-gaming/robotk/pull/37/files#diff-cca7988427412b723d91027554201998R168))